### PR TITLE
Go lang Installation

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -1,0 +1,12 @@
+#Script to install Go on Ubuntu systems <= 15.10
+
+wget https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz
+
+tar -C /usr/local -xzf go1.6.2.linux-amd64.tar.gz
+
+cd ~
+mkdir go
+
+echo "export GOPATH=$HOME/go" >> .bashrc
+echo "export GOROOT=/usr/local/go" >> .bashrc
+echo "export PATH=$PATH:$GOROOT/bin:$GOPATH/bin" >> .bashrc

--- a/go16.sh
+++ b/go16.sh
@@ -1,0 +1,10 @@
+#Script to install Go on Ubuntu systems >= 16.04
+
+sudo apt install golang-go
+
+cd ~
+mkdir go
+
+echo "export GOPATH=$HOME/go" >> .bashrc
+echo "export GOROOT=/usr/lib/go" >> .bashrc
+echo "export PATH=$PATH:$GOROOT/bin:$GOPATH/bin" >> .bashrc


### PR DESCRIPTION
Created 2 distinguished scripts for Ubuntu 15.10 and 16.04 respectively, as Go lang is now supported under Apt installation from 16.04
